### PR TITLE
Increase HTTP timeoutIntervalForRequest to 10 seconds

### DIFF
--- a/HomeAssistant/HAAPI.swift
+++ b/HomeAssistant/HAAPI.swift
@@ -118,7 +118,7 @@ public class HomeAssistantAPI {
 
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = defaultHeaders
-        configuration.timeoutIntervalForRequest = 3 // seconds
+        configuration.timeoutIntervalForRequest = 10 // seconds
 
         self.manager = Alamofire.SessionManager(configuration: configuration)
 


### PR DESCRIPTION
[Apple's default is 60 seconds](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408259-timeoutintervalforrequest) and the current 3 seconds doesn't seem like enough time for many internet connections.

I'm hoping this will help with #33