### PR TITLE
Default camera category attachments to jpeg content-type

### DIFF
--- a/APNSAttachmentService/NotificationService.swift
+++ b/APNSAttachmentService/NotificationService.swift
@@ -51,6 +51,9 @@ final class NotificationService: UNNotificationServiceExtension {
                 return failEarly()
             }
             incomingAttachment["url"] = "\(baseURL)/api/camera_proxy/\(entityId)?api_password=\(apiPassword)"
+            if incomingAttachment["content-type"] == nil {
+                incomingAttachment["content-type"] = "jpeg"
+            }
         } else {
             // Check if we still have an empty dictionary
             if incomingAttachment.isEmpty {


### PR DESCRIPTION
Mostly fixes #39 

In the case where we're a camera notification and there is no custom attachment URL, we know that we have a URL like

> \(baseURL)/api/camera_proxy/\(entityId)?api_password=\(apiPassword)

which doesn't have a suffix for UNNotificationAttachment to auto-detect the content-type.

In this case we should default to "jpeg" since that's what "camera_proxy" seems to normally return. This saves users from having to manually specify the content-type for camera stream thumbnails in most cases.