### PR TITLE
Add the version string to the about page

### DIFF
--- a/HomeAssistant/Views/AboutViewController.swift
+++ b/HomeAssistant/Views/AboutViewController.swift
@@ -29,6 +29,9 @@ class AboutViewController: FormViewController {
                                                                                   bundle: nil))
                 logoHeader.onSetupView = { view, _ in
                     view.AppTitle.text = L10n.About.Logo.appTitle
+                    if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                        view.Version.text = version
+                    }
                     view.Tagline.text = L10n.About.Logo.tagline
                 }
                 $0.header = logoHeader
@@ -200,6 +203,7 @@ class HomeAssistantLogoView: UIView {
 
     @IBOutlet weak var AppTitle: UILabel!
     @IBOutlet weak var Tagline: UILabel!
+    @IBOutlet weak var Version: UILabel!
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }

--- a/HomeAssistant/Views/HomeAssistantLogoView.xib
+++ b/HomeAssistant/Views/HomeAssistantLogoView.xib
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="HomeAssistantLogoView" customModule="HomeAssistant" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="173"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="HomeAssistantLogoView" customModule="Home_Assistant" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="190"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="SvT-RD-CiP">
@@ -22,13 +23,13 @@
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Awaken Your Home" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmk-xi-0r6">
-                    <rect key="frame" x="108" y="147" width="158" height="21"/>
+                    <rect key="frame" x="108" y="168" width="158" height="21"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Home Assistant for iOS" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bd2-me-S0Q">
-                    <rect key="frame" x="99" y="126" width="177" height="21"/>
+                    <rect key="frame" x="99" y="126.5" width="177" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="177" id="QQm-OY-bpk"/>
                     </constraints>
@@ -36,12 +37,23 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="x.y" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pcW-UY-tZO">
+                    <rect key="frame" x="98.5" y="147.5" width="177" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="177" id="auc-L0-565"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <constraints>
-                <constraint firstItem="vmk-xi-0r6" firstAttribute="top" secondItem="bd2-me-S0Q" secondAttribute="bottom" id="Gji-AQ-Hic"/>
-                <constraint firstItem="vmk-xi-0r6" firstAttribute="top" secondItem="SvT-RD-CiP" secondAttribute="bottom" constant="15" id="IUi-4e-izy"/>
+                <constraint firstItem="pcW-UY-tZO" firstAttribute="top" secondItem="bd2-me-S0Q" secondAttribute="bottom" id="7wx-my-d5Z"/>
+                <constraint firstItem="vmk-xi-0r6" firstAttribute="top" secondItem="pcW-UY-tZO" secondAttribute="bottom" id="Gji-AQ-Hic"/>
+                <constraint firstItem="vmk-xi-0r6" firstAttribute="top" secondItem="SvT-RD-CiP" secondAttribute="bottom" constant="36" id="IUi-4e-izy"/>
                 <constraint firstItem="SvT-RD-CiP" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Mc3-w9-5GM"/>
                 <constraint firstItem="SvT-RD-CiP" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="RPp-bn-iol"/>
+                <constraint firstItem="pcW-UY-tZO" firstAttribute="centerX" secondItem="SvT-RD-CiP" secondAttribute="centerX" id="X1m-Ij-AQs"/>
                 <constraint firstItem="SvT-RD-CiP" firstAttribute="centerX" secondItem="bd2-me-S0Q" secondAttribute="centerX" id="dHG-Ef-uGh"/>
                 <constraint firstItem="SvT-RD-CiP" firstAttribute="centerX" secondItem="vmk-xi-0r6" secondAttribute="centerX" id="pof-tX-8dW"/>
             </constraints>
@@ -52,8 +64,9 @@
             <connections>
                 <outlet property="AppTitle" destination="bd2-me-S0Q" id="ghK-nu-0uL"/>
                 <outlet property="Tagline" destination="vmk-xi-0r6" id="ina-0e-QV1"/>
+                <outlet property="Version" destination="pcW-UY-tZO" id="LtS-lY-cyL"/>
             </connections>
-            <point key="canvasLocation" x="-18.5" y="-236.5"/>
+            <point key="canvasLocation" x="-18.5" y="-228"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
From https://github.com/home-assistant/home-assistant-iOS/issues/25#issuecomment-313744559 
> On that note- should probably make the iOS app version number more obvious

Otherwise it's buried in Storage settings or by looking at the App Store

Asking for review since I haven't edited a xib file in years.

![simulator screen shot - iphone 6 - 2017-10-24 at 22 01 30](https://user-images.githubusercontent.com/601139/31981429-195f7594-b908-11e7-94ec-c27bcd22d73a.png)
