### PR TITLE
Don't hardcode AppIdentifierPrefix in Keychain constructor

### DIFF
--- a/APNSAttachmentService/NotificationService.swift
+++ b/APNSAttachmentService/NotificationService.swift
@@ -28,7 +28,7 @@ final class NotificationService: UNNotificationServiceExtension {
             contentHandler(request.content)
         }
 
-        let keychain = Keychain(service: "io.robbie.homeassistant", accessGroup: "UTQFCBPQRF.io.robbie.HomeAssistant")
+        let keychain = Keychain(service: "io.robbie.homeassistant")
         guard let baseURL = keychain["baseURL"] else {
             return failEarly()
         }

--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -15,7 +15,7 @@ import AlamofireNetworkActivityIndicator
 import KeychainAccess
 import SwiftLocation
 
-let keychain = Keychain(service: "io.robbie.homeassistant", accessGroup: "UTQFCBPQRF.io.robbie.HomeAssistant")
+let keychain = Keychain(service: "io.robbie.homeassistant")
 
 let prefs = UserDefaults(suiteName: "group.io.robbie.homeassistant")!
 

--- a/NotificationContentExtension/NotificationViewController.swift
+++ b/NotificationContentExtension/NotificationViewController.swift
@@ -25,7 +25,7 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let keychain = Keychain(service: "io.robbie.homeassistant", accessGroup: "UTQFCBPQRF.io.robbie.HomeAssistant")
+        let keychain = Keychain(service: "io.robbie.homeassistant")
         if let url = keychain["baseURL"] {
             baseURL = url
         }


### PR DESCRIPTION
This makes it so device builds can work if the developer isn't in Robbie's team (UTQFCBPQRF).

According to https://developer.apple.com/library/content/documentation/Security/Conceptual/keychainServConcepts/02concepts/concepts.html#//apple_ref/doc/uid/TP30000897-CH204-SW1 defining `keychain-access-groups` in the entitlements means "apps would add new keychain items to that access group by default". We already have "$(AppIdentifierPrefix)io.robbie.HomeAssistant" in all of the entitlements files so it seems like specifying the accessGroup isn't necessary.

@robbiet480 Can you test that your saved login is still accessible if you upgrade to a build with this PR? According to the docs it should work and this will make it easier for other to contribute to the app.