### PR TITLE
Disable webview bouncing

### DIFF
--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -53,6 +53,8 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, C
 
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
+        webView.scrollView.bounces = false
+
         HomeAssistantAPI.sharedInstance.Setup(baseURLString: keychain["baseURL"], password: keychain["apiPassword"],
                                               deviceID: keychain["deviceID"])
         if HomeAssistantAPI.sharedInstance.Configured {


### PR DESCRIPTION
When the webview's scrollview is allowed to bounce it sometimes scrolls
to its bouncing margins when the user intended to scroll the page loaded
in the web view. This results in ugly and annoying effects such as the
top bar of the web interface scrolling down from the status bar. Since
the loaded page has a bouncing effect anyway it seems natural to disable
this capability.