### PR TITLE
Remove invalid service data for device_tracker.see

### DIFF
--- a/HomeAssistant/HAAPI.swift
+++ b/HomeAssistant/HAAPI.swift
@@ -208,10 +208,8 @@ public class HomeAssistantAPI {
 
         let locationUpdate: [String: Any] = [
             "battery": Int(UIDevice.current.batteryLevel*100),
-            "battery_status": batteryState,
             "gps": [coordinates.latitude, coordinates.longitude],
             "gps_accuracy": accuracy,
-            "hostname": hostname,
             "dev_id": deviceID
         ]
 

--- a/HomeAssistant/HAAPI.swift
+++ b/HomeAssistant/HAAPI.swift
@@ -192,20 +192,6 @@ public class HomeAssistantAPI {
                         zone: Zone?) {
         UIDevice.current.isBatteryMonitoringEnabled = true
 
-        var batteryState = "Unplugged"
-        switch UIDevice.current.batteryState {
-        case .unknown:
-            batteryState = "Unknown"
-        case .charging:
-            batteryState = "Charging"
-        case .unplugged:
-            batteryState = "Unplugged"
-        case .full:
-            batteryState = "Full"
-        }
-
-        let hostname = UIDevice().name
-
         let locationUpdate: [String: Any] = [
             "battery": Int(UIDevice.current.batteryLevel*100),
             "gps": [coordinates.latitude, coordinates.longitude],


### PR DESCRIPTION
So first off, this is completely untested.

Starting Home Assistant 0.65, we've added service data validation to the device tracker see service. Once released, we realized that iOS app sends invalid data. This will remove those keys.

I saw one more reference to the device tracker see service, but it seems that any other app can define the data that is being sent (is that secure?)

https://github.com/home-assistant/home-assistant-iOS/blob/545ed6a7d48b70f9cb7de4c889dddfe65f48a486/HomeAssistant/AppDelegate.swift#L231