### PR TITLE
Set location name to not_home on zone exit for all zones

### DIFF
--- a/Shared/API/Models/DeviceTrackerSee.swift
+++ b/Shared/API/Models/DeviceTrackerSee.swift
@@ -65,8 +65,19 @@ public class DeviceTrackerSee: Mappable {
                 self.LocationName = LocationNames.Home
             case .RegionExit, .GPSRegionExit:
                 self.LocationName =  LocationNames.NotHome
+                self.ClearLocation()
             case .BeaconRegionExit:
                 self.ConsiderHome = TimeInterval(exactly: 180)
+                self.ClearLocation()
+            default:
+                break
+            }
+        } else { // Other zones
+            switch self.Trigger {
+            case .RegionExit, .GPSRegionExit:
+                self.LocationName =  LocationNames.NotHome
+                self.ClearLocation()
+            case .BeaconRegionExit:
                 self.ClearLocation()
             default:
                 break


### PR DESCRIPTION
Addresses issue #29 where region monitoring does not send the not_home state when leaving a zone. Previously this only happened when leaving the "home" zone. This commit adds this state for any zone, so that region exit automations can be triggered in a timely manner.