### PR TITLE
GPS region exits will send location coordinates (new), whilst beacon triggers will send location name (unchanged)

### DIFF
--- a/HomeAssistant/Classes/RegionManager.swift
+++ b/HomeAssistant/Classes/RegionManager.swift
@@ -118,7 +118,7 @@ class RegionManager: NSObject {
 
         let message = "Submitting location for zone \(zone.ID) with trigger \(trig.rawValue)."
         Current.clientEventStore.addEvent(ClientEvent(text: message, type: .locationUpdate))
-        api.submitLocation(updateType: trig, location: nil, zone: zone).done {
+        api.submitLocation(updateType: trig, location: self.locationManager.location, zone: zone).done {
             let message = "Succeeded updating zone \(zone.ID) with trigger \(trig.rawValue)."
             Current.clientEventStore.addEvent(ClientEvent(text: message, type: .locationUpdate))
         }.ensure {

--- a/Shared/API/Models/DeviceTrackerSee.swift
+++ b/Shared/API/Models/DeviceTrackerSee.swift
@@ -48,7 +48,7 @@ public class DeviceTrackerSee: Mappable {
         self.SourceType = (self.Trigger == .BeaconRegionEnter || self.Trigger == .BeaconRegionExit
             ? .BluetoothLowEnergy : .GlobalPositioningSystem)
 
-        if let location = location {
+        if let location = location, (trigger != .BeaconRegionEnter && trigger != .BeaconRegionExit) {
             self.SetLocation(location: location)
         } else if let zone = zone {
             self.SetZone(zone: zone)


### PR DESCRIPTION
This PR restores the GPS functionality (which was removed in https://github.com/home-assistant/home-assistant-iOS/commit/c3a9cd2a37d3e018b9a3587b19d059958c82dc83) without affecting beacons.

The issue with the previous code, was that the setZone code was always unreachable. Meaning that the location code always ran (providing solid GPS results), but beacon/zone logic never ran.

This update will prefer location coordinates over zone, unless the event is triggered by a beacon. If a beacon triggers the event, then the previous functionality will apply for setting the zone.