### PR TITLE
Do nothing on non-home iBeacon exits for now

### DIFF
--- a/Shared/API/Models/DeviceTrackerSee.swift
+++ b/Shared/API/Models/DeviceTrackerSee.swift
@@ -76,8 +76,7 @@ public class DeviceTrackerSee: Mappable {
             case .BeaconRegionEnter:
                 self.LocationName = zone.Name
             case .BeaconRegionExit:
-                self.ConsiderHome = TimeInterval(exactly: 180)
-                self.ClearLocation()
+                break
             default:
                 break
             }


### PR DESCRIPTION
Currently, non-home zone iBeacon exits will unintentionally result in a change to `home`. This skips exit logic for now until it's decided how to properly handle these triggers.