### PR TITLE
Fixing log message typos

### DIFF
--- a/HomeAssistant/Classes/RegionManager.swift
+++ b/HomeAssistant/Classes/RegionManager.swift
@@ -104,8 +104,8 @@ class RegionManager: NSObject {
 
         let inRegion = (trigger == .RegionEnter)
         guard zone.inRegion != inRegion else {
-            let noChangeMessage = "Not updating \(zone.debugDescription) because  DB already believes state" +
-            "to be corrrect. (\(zone.inRegion ? "In" : "out")). Trigger: \(trigger)"
+            let noChangeMessage = "Not updating \(zone.debugDescription) because DB already believes state " +
+            "to be correct. (\(zone.inRegion ? "In" : "out")). Trigger: \(trigger)"
             print(noChangeMessage)
             Current.clientEventStore.addEvent(ClientEvent(text: noChangeMessage, type: .locationUpdate))
             return
@@ -254,7 +254,7 @@ extension RegionManager: CLLocationManagerDelegate {
         }
 
         guard last.horizontalAccuracy <= 200 else {
-            let inaccurateLocationMessage = "Ignoring location with accurace over threshold." +
+            let inaccurateLocationMessage = "Ignoring location with accuracy over threshold." +
             "Accuracy: \(last.horizontalAccuracy)m"
             print(inaccurateLocationMessage)
             Current.clientEventStore.addEvent(ClientEvent(text: inaccurateLocationMessage,
@@ -264,7 +264,7 @@ extension RegionManager: CLLocationManagerDelegate {
 
         let locationAge = Current.date().timeIntervalSince(last.timestamp)
         if locationAge > kLocationMaximumAge {
-            print("Location is older than threshhold. ")
+            print("Location is older than threshhold.")
             return
         }
 

--- a/HomeAssistant/Classes/RegionManager.swift
+++ b/HomeAssistant/Classes/RegionManager.swift
@@ -264,7 +264,7 @@ extension RegionManager: CLLocationManagerDelegate {
 
         let locationAge = Current.date().timeIntervalSince(last.timestamp)
         if locationAge > kLocationMaximumAge {
-            print("Location is older than threshhold.")
+            print("Location is older than threshold.")
             return
         }
 


### PR DESCRIPTION
A few Event Log message typos have been bothering me, here's some fixes.