### PR TITLE
iBeacon exit attempt v2

### DIFF
--- a/HomeAssistant/Classes/RegionManager.swift
+++ b/HomeAssistant/Classes/RegionManager.swift
@@ -120,6 +120,7 @@ class RegionManager: NSObject {
             let noChangeMessage = "Not updating \(zone.debugDescription) because iBeacon exits are ignored"
             print(noChangeMessage)
             Current.clientEventStore.addEvent(ClientEvent(text: noChangeMessage, type: .locationUpdate))
+            self.endBackgroundTaskWithName(taskName)
             return
         }
 

--- a/HomeAssistant/Classes/RegionManager.swift
+++ b/HomeAssistant/Classes/RegionManager.swift
@@ -116,6 +116,13 @@ class RegionManager: NSObject {
             zone.inRegion = inRegion
         }
 
+        guard trig != .BeaconRegionExit else {
+            let noChangeMessage = "Not updating \(zone.debugDescription) because iBeacon exits are ignored"
+            print(noChangeMessage)
+            Current.clientEventStore.addEvent(ClientEvent(text: noChangeMessage, type: .locationUpdate))
+            return
+        }
+
         let message = "Submitting location for zone \(zone.ID) with trigger \(trig.rawValue)."
         Current.clientEventStore.addEvent(ClientEvent(text: message, type: .locationUpdate))
         api.submitLocation(updateType: trig, location: self.locationManager.location, zone: zone).done {


### PR DESCRIPTION
**Experimental test**

Don't immediately notify HA when exiting an iBeacon region, but still update the zone object.

Ideally will avoid iBeacon exits from non-home zones triggering a state change to `home` and falling back to GPS.