### PR TITLE
Pass actionName to UIApplicationShortcutItem and use rather the HA text value

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -274,7 +274,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return
         }
 
-        let name = shortcutItem.localizedTitle
+        let name = shortcutItem.userInfo
         let actionPromise = api.HandleAction(actionID: shortcutItem.type, actionName: name,
                                              source: .AppShortcut)
 

--- a/HomeAssistant/Classes/Action.swift
+++ b/HomeAssistant/Classes/Action.swift
@@ -68,7 +68,7 @@ public class Action: Object, Mappable, NSCoding {
 
     #if os(iOS)
     public var uiShortcut: UIApplicationShortcutItem {
-        return UIApplicationShortcutItem(type: self.ID, localizedTitle: self.Text)
+        return UIApplicationShortcutItem(type: self.ID, localizedTitle: self.Text, userInfo: self.Name)
     }
     #endif
 }


### PR DESCRIPTION
So I should start this PR by saying I suspect it won't work (hence creating as draft)... This is just my very very newbie attempt to fix #505. The idea is to user the optional `userInfo` key of [`UIApplicationShortcutItem`](https://developer.apple.com/documentation/uikit/uiapplicationshortcutitem) to pass the action name defined with the App and then to use that value with `api.HandleAction`. Currently `UIApplicationShortcutItem`s only knew about the value of the `text` field in the app and passed that to the HA event bus causing automations to fail if `name != text` which is a perfectly valid case. Feel free to ignore and implement a correct fix.