### PR TITLE
Fix typo in German localization

### DIFF
--- a/HomeAssistant/Resources/de.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/de.lproj/Localizable.strings
@@ -132,7 +132,7 @@ an dieses Gerät gesschickt.";
 "location_change_notification.region_enter.body" = "%@ betreten";
 "location_change_notification.region_exit.body" = "%@ verlassen";
 "location_change_notification.significant_location_update.body" = "Standortaktualisierung: Erhebliche Standortänderung";
-"location_change_notification.background_fetch.body" = "Standortaktualisierung: Hintergrundaktualisierungt";
+"location_change_notification.background_fetch.body" = "Standortaktualisierung: Hintergrundaktualisierung";
 "about.review.title" = "Bewerte diese App";
 "settings.event_log.title" = "Ereignisprotokoll";
 "settings_details.location.notifications.push_notification.title" = "Anfrage via Push";


### PR DESCRIPTION
Remove superfluous "t" at the end of the string.