### PR TITLE
Add translation details to readme.md and contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,4 @@
  - Write the code.
  - Ensure tests work.
  - Create a Pull Request against the [**master**](https://github.com/home-assistant/home-assistant-iOS/tree/master) branch of Home Assistant.
+- **Translations** are handled by [lokalise.com](https://lokalise.com/public/834452985a05254348aee2.46389241/), we are always looking to add more translations and complete the ones we already have. If you would like to contribute to the translation of the app, please visit [lokalise.com](https://lokalise.com/public/834452985a05254348aee2.46389241/) and join the team.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ To keep the Xcode layout mirrored with on-disk layout we're using [Synx](https:/
 - [MBProgressHUD](https://github.com/jdg/MBProgressHUD): MBProgressHUD + Customizations
 - [Whisper](https://github.com/hyperoslo/Whisper): Whisper is a component that will make the task of display messages and in-app notifications simple. It has three different views inside
 
+### Translations
+-  [Lokalise](https://lokalise.com/public/834452985a05254348aee2.46389241/): Translations are handled through Lokalise and not through this repository. To contribute to the translations please join the [Lokalise](https://lokalise.com/public/834452985a05254348aee2.46389241/) team.
+
 ### Utilities
 
 - [DeviceKit](https://github.com/dennisweissmann/DeviceKit): DeviceKit is a value-type replacement of UIDevice.


### PR DESCRIPTION
We've had a couple of people (#532 and #476) contribute translations here. The current guides did not contain any information suggesting this was not the correct thing to do. Added a couple of lines to both `README.md` and `CONTRIBUTING.md` to help.